### PR TITLE
Implement fetching IPFS resources

### DIFF
--- a/lib/gofer/Cargo.toml
+++ b/lib/gofer/Cargo.toml
@@ -23,7 +23,7 @@ std = [
     "percent-encoding?/std",
     "thiserror/std",
 ]
-all = ["data", "file", "ftp", "http", "https", "stdin"]
+all = ["data", "file", "ftp", "http", "https", "ipfs", "stdin"]
 unstable = ["ftps", "git", "scp"]
 
 # Protocols:
@@ -34,6 +34,7 @@ ftps = ["ftp", "suppaftp?/rustls"]
 git = ["dep:gix-protocol"]
 http = ["dep:reqwest", "reqwest?/blocking"]
 https = ["http", "reqwest?/default", "reqwest?/rustls-tls-native-roots"]
+ipfs = ["dep:reqwest", "reqwest?/blocking"]
 scp = ["dep:ssh2"]
 stdin = ["std"]
 
@@ -45,26 +46,26 @@ miette = ["dep:miette"]
 
 [dependencies]
 clap = { version = "4.5", default-features = false, features = [
-    "derive",
-    "help",
+	"derive",
+	"help",
 ], optional = true }
 data-url = { version = "0.3", default-features = false, features = [
-    "alloc",
+	"alloc",
 ], optional = true }
 dogma = { version = "0.1.5", default-features = false, features = [
-    "iri",
-    "uri",
+	"iri",
+	"uri",
 ] }
 gix-protocol = { version = "0.49", default-features = false, features = [
-    "blocking-client",
+	"blocking-client",
 ], optional = true }
 miette = { version = "7.5", default-features = false, features = [
-    "derive",
+	"derive",
 ], optional = true }
 percent-encoding = { version = "2.3", default-features = false, optional = true }
 reqwest = { version = "0.12", default-features = false, optional = true }
 ssh2 = { version = "0.9", default-features = false, features = [
-    "vendored-openssl",
+	"vendored-openssl",
 ], optional = true }
 suppaftp = { version = "6", default-features = false, optional = true }
 thiserror = { version = "2", default-features = false }

--- a/lib/gofer/Cargo.toml
+++ b/lib/gofer/Cargo.toml
@@ -46,26 +46,26 @@ miette = ["dep:miette"]
 
 [dependencies]
 clap = { version = "4.5", default-features = false, features = [
-	"derive",
-	"help",
+    "derive",
+    "help",
 ], optional = true }
 data-url = { version = "0.3", default-features = false, features = [
-	"alloc",
+    "alloc",
 ], optional = true }
 dogma = { version = "0.1.5", default-features = false, features = [
-	"iri",
-	"uri",
+    "iri",
+    "uri",
 ] }
 gix-protocol = { version = "0.49", default-features = false, features = [
-	"blocking-client",
+    "blocking-client",
 ], optional = true }
 miette = { version = "7.5", default-features = false, features = [
-	"derive",
+    "derive",
 ], optional = true }
 percent-encoding = { version = "2.3", default-features = false, optional = true }
 reqwest = { version = "0.12", default-features = false, optional = true }
 ssh2 = { version = "0.9", default-features = false, features = [
-	"vendored-openssl",
+    "vendored-openssl",
 ], optional = true }
 suppaftp = { version = "6", default-features = false, optional = true }
 thiserror = { version = "2", default-features = false }

--- a/lib/gofer/examples/ipfs.rs
+++ b/lib/gofer/examples/ipfs.rs
@@ -1,0 +1,12 @@
+// This is free and unencumbered software released into the public domain.
+
+use std::{boxed::Box, error::Error, io::stdout, result::Result};
+
+pub fn main() -> Result<(), Box<dyn Error>> {
+    let mut output = stdout().lock();
+    let mut input =
+        gofer::open("ipfs://bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m")?;
+    std::io::copy(&mut input, &mut output)?;
+
+    Ok(())
+}

--- a/lib/gofer/src/error.rs
+++ b/lib/gofer/src/error.rs
@@ -112,6 +112,18 @@ pub enum Error {
         )
     )]
     FailedHttpRequest(#[from] reqwest::Error),
+
+    #[cfg(feature = "ipfs")]
+    #[error("invalid IPFS URL: {0}")]
+    #[cfg_attr(
+        feature = "miette",
+        diagnostic(
+            code(gofer::invalid_ipfs_url),
+            help("it seems that the URL is malformed in some way"),
+            url(docsrs),
+        )
+    )]
+    InvalidIpfsUrl(String),
 }
 
 #[cfg(feature = "std")]
@@ -142,6 +154,9 @@ impl Into<std::io::Error> for Error {
 
             #[cfg(any(feature = "http", feature = "https"))]
             Error::FailedHttpRequest(_e) => std::io::Error::from(ErrorKind::Other), // FIXME
+
+            #[cfg(feature = "ipfs")]
+            Error::InvalidIpfsUrl(u) => std::io::Error::new(ErrorKind::InvalidInput, u.as_str()),
         }
     }
 }

--- a/lib/gofer/src/error.rs
+++ b/lib/gofer/src/error.rs
@@ -127,10 +127,10 @@ pub enum Error {
 }
 
 #[cfg(feature = "std")]
-impl Into<std::io::Error> for Error {
-    fn into(self) -> std::io::Error {
+impl From<Error> for std::io::Error {
+    fn from(value: Error) -> Self {
         use std::io::ErrorKind;
-        match self {
+        match value {
             Error::InvalidUrl(e) => std::io::Error::new(ErrorKind::InvalidInput, e),
             Error::UnknownScheme(s) => std::io::Error::new(ErrorKind::InvalidInput, s),
 

--- a/lib/gofer/src/open.rs
+++ b/lib/gofer/src/open.rs
@@ -29,6 +29,9 @@ pub fn open(url: impl AsRef<str>) -> Result<Box<dyn Read>> {
         #[cfg(feature = "https")]
         UrlScheme::Https => crate::schemes::http::open(&url, true),
 
+        #[cfg(feature = "ipfs")]
+        UrlScheme::Ipfs => crate::schemes::ipfs::open(&url),
+
         #[cfg(feature = "scp")]
         UrlScheme::Scp => crate::schemes::scp::open(&url),
 

--- a/lib/gofer/src/schemes.rs
+++ b/lib/gofer/src/schemes.rs
@@ -15,6 +15,9 @@ pub mod git;
 #[cfg(any(feature = "http", feature = "https"))]
 pub mod http;
 
+#[cfg(feature = "ipfs")]
+pub mod ipfs;
+
 #[cfg(feature = "scp")]
 pub mod scp;
 

--- a/lib/gofer/src/schemes/ipfs.rs
+++ b/lib/gofer/src/schemes/ipfs.rs
@@ -1,0 +1,28 @@
+// This is free and unencumbered software released into the public domain.
+
+use crate::{Error, Read, Result, Url};
+use reqwest::{blocking::ClientBuilder, redirect};
+
+static USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+static GATEWAY: &str = "https://ipfs.io";
+
+/// See: https://en.wikipedia.org/wiki/InterPlanetary_File_System
+pub fn open<'a, 'b>(url: &'a Url<'b>) -> Result<Box<dyn Read>> {
+    // See: https://docs.rs/reqwest/latest/reqwest/blocking/struct.ClientBuilder.html
+    let client = ClientBuilder::new()
+        .user_agent(USER_AGENT)
+        .redirect(redirect::Policy::default())
+        .https_only(true);
+
+    let url = url
+        .as_str()
+        .strip_prefix("ipfs://")
+        .ok_or_else(|| Error::InvalidIpfsUrl(url.to_string()))
+        .map(|id| format!("{}/ipfs/{}", GATEWAY, id))?;
+
+    // See: https://docs.rs/reqwest/latest/reqwest/blocking/struct.Client.html#method.get
+    // See: https://docs.rs/reqwest/latest/reqwest/blocking/struct.RequestBuilder.html
+    let response = client.build()?.get(url).send()?;
+
+    Ok(Box::new(response))
+}


### PR DESCRIPTION
Should I include `Cargo.lock` changes here after running `cargo update` to get the latest [known-schemes@0.1.1](https://github.com/known-facts/known-schemes/commit/d99dc8ce3bff93fcaeaa5079ce719dde7753a0e3) for the `IPFS` scheme or should the lockfile be deleted altogether since this is a lib?

Verify:
```console
$ cargo run -q --example ipfs
Hello from IPFS Gateway Checker
```
Matches: https://ipfs.io/ipfs/bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m